### PR TITLE
Implemented tests for product repository and orders repository

### DIFF
--- a/lib/app/core/data/orders/orders_repository.dart
+++ b/lib/app/core/data/orders/orders_repository.dart
@@ -50,9 +50,8 @@ class OrdersRepository implements IOrdersRepository {
   @override
   Future<int> createOrder(OrderDTO orderDTO) async {
     final Database connection = await _connection.openConnection();
-    late int orderId;
-    await connection.transaction((txn) async {
-      orderId = await txn
+    final int orderId = await connection.transaction((txn) async {
+      int id = await txn
           .rawInsert('INSERT INTO orders(table_number, status) VALUES (?, ?)', [
         orderDTO.tableNumber,
         orderDTO.status ? 1 : 0,
@@ -61,11 +60,12 @@ class OrdersRepository implements IOrdersRepository {
         await txn.rawInsert('''
           INSERT INTO orders_has_products(orders_id, products_id, quantity) VALUES (?, ?, ?)
         ''', [
-          orderId,
+          id,
           productDTO.id,
           productDTO.quantity,
         ]);
       }
+      return id;
     });
     return orderId;
   }
@@ -81,9 +81,9 @@ class OrdersRepository implements IOrdersRepository {
   @override
   Future<int> updateOrder(OrderDTO updatedOrder) async {
     final Database connection = await _connection.openConnection();
-    late int updatedOrdersCount;
-    await connection.transaction((txn) async {
-      updatedOrdersCount = await txn.rawUpdate('''
+
+    final int updatedOrdersCount = await connection.transaction((txn) async {
+      int count = await txn.rawUpdate('''
         UPDATE orders
         SET table_number = ?, status = ?
         WHERE id = ?
@@ -103,6 +103,7 @@ class OrdersRepository implements IOrdersRepository {
           productDTO.quantity,
         ]);
       }
+      return count;
     });
     return updatedOrdersCount;
   }
@@ -114,7 +115,7 @@ class OrdersRepository implements IOrdersRepository {
       SELECT o.id as id,
       o.table_number as table_number,
       o.status as status
-      FROM orders as o 
+      FROM orders as o
       WHERE o.status = ?
       ''', [1]);
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -148,6 +148,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
+  coverage:
+    dependency: transitive
+    description:
+      name: coverage
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.3"
   crypto:
     dependency: transitive
     description:
@@ -340,6 +347,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.4"
+  mocktail:
+    dependency: "direct dev"
+    description:
+      name: mocktail
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0"
+  node_preamble:
+    dependency: transitive
+    description:
+      name: node_preamble
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   package_config:
     dependency: transitive
     description:
@@ -354,6 +375,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
+  pedantic:
+    dependency: transitive
+    description:
+      name: pedantic
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.11.1"
   pool:
     dependency: transitive
     description:
@@ -382,6 +410,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
+  shelf_packages_handler:
+    dependency: transitive
+    description:
+      name: shelf_packages_handler
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0"
+  shelf_static:
+    dependency: transitive
+    description:
+      name: shelf_static
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   shelf_web_socket:
     dependency: transitive
     description:
@@ -401,6 +443,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.1"
+  source_map_stack_trace:
+    dependency: transitive
+    description:
+      name: source_map_stack_trace
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.0"
+  source_maps:
+    dependency: transitive
+    description:
+      name: source_maps
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.10.10"
   source_span:
     dependency: transitive
     description:
@@ -464,6 +520,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
+  test:
+    dependency: transitive
+    description:
+      name: test
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.17.10"
   test_api:
     dependency: transitive
     description:
@@ -471,6 +534,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.2"
+  test_core:
+    dependency: transitive
+    description:
+      name: test_core
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.0"
   timing:
     dependency: transitive
     description:
@@ -492,6 +562,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "7.5.0"
   watcher:
     dependency: transitive
     description:
@@ -506,6 +583,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  webkit_inspection_protocol:
+    dependency: transitive
+    description:
+      name: webkit_inspection_protocol
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,7 @@ dev_dependencies:
   build_runner: ^2.1.5
   injectable_generator: ^1.5.2
   mobx_codegen: ^2.0.4
+  mocktail: ^0.2.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/app/core/data/orders/orders_repository_test.dart
+++ b/test/app/core/data/orders/orders_repository_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:quiosque/app/core/data/dtos/order_dto.dart';
+import 'package:quiosque/app/core/data/orders/orders_repository.dart';
+import 'package:quiosque/app/core/database/db_connection.dart';
+import 'package:sqflite/sqflite.dart';
+
+import '../../../../mocked_data.dart';
+
+class DatabaseMock extends Mock implements Database {}
+
+class DbConnectionMock extends Mock implements DbConnection {}
+
+void main() {
+  final dbConnectionMock = DbConnectionMock();
+  final databaseMock = DatabaseMock();
+  final OrdersRepository ordersRepository = OrdersRepository(dbConnectionMock);
+
+  setUp(() {
+    when(() => dbConnectionMock.openConnection())
+        .thenAnswer((_) async => databaseMock);
+  });
+  test('Should return a list of orders', () async {
+    when(() => databaseMock.rawQuery(''' 
+      SELECT o.id as id,
+      o.table_number as table_number,
+      o.status as status
+      FROM orders as o 
+      ''')).thenAnswer((_) async => mockedOrdersList);
+    for (var item in mockedOrdersList) {
+      when(() => databaseMock.rawQuery(''' 
+        SELECT id, product, price, ohp.quantity AS quantity
+        FROM products
+        JOIN orders_has_products as ohp ON ohp.products_id = id
+        WHERE ohp.orders_id = ?;
+      ''', [item['id']])).thenAnswer((_) async => []);
+    }
+
+    final result = await ordersRepository.getAllOrders();
+
+    expect(result.length, 3);
+  });
+
+  test('Should return a list with active orders only', () async {
+    final List<Map<String, dynamic>> activeOrders =
+        mockedOrdersList.where((orderMap) => orderMap['status'] == 1).toList();
+    when(() => databaseMock.rawQuery(''' 
+      SELECT o.id as id,
+      o.table_number as table_number,
+      o.status as status
+      FROM orders as o
+      WHERE o.status = ?
+      ''', [1])).thenAnswer((_) async => activeOrders);
+
+    for (var item in activeOrders) {
+      when(() => databaseMock.rawQuery(''' 
+        SELECT id, product, price, ohp.quantity AS quantity
+        FROM products
+        JOIN orders_has_products as ohp ON ohp.products_id = id
+        WHERE ohp.orders_id = ?;
+      ''', [item['id']])).thenAnswer((_) async => []);
+    }
+
+    final result = await ordersRepository.getActiveOrders();
+
+    expect(result.length, 2);
+  });
+
+  test('Should return id on order creation', () async {
+    when(() => databaseMock.transaction(any()))
+        .thenAnswer((_) async => mockedOrdersList.length + 1);
+    when(() => databaseMock.rawInsert(any()))
+        .thenAnswer((_) async => mockedOrdersList.length + 1);
+
+    final OrderDTO newOrder = OrderDTO(tableNumber: 3, products: []);
+    final int result = await ordersRepository.createOrder(newOrder);
+
+    expect(result, mockedOrdersList.length + 1);
+  });
+
+  test('Should return number of lines affected by order deletion', () async {
+    when(() => databaseMock.rawDelete(any(), [3])).thenAnswer((_) async => 1);
+
+    final int result = await ordersRepository.deleteOrder(3);
+    expect(result, 1);
+  });
+
+  test('Should return number of lines affected by order update', () async {
+    final OrderDTO updatedOrder = OrderDTO(id: 4, tableNumber: 3, products: []);
+
+    when(() => databaseMock.transaction(any())).thenAnswer((_) async => 1);
+    when(() => databaseMock.rawUpdate(any(), [
+          updatedOrder.tableNumber,
+          updatedOrder.status ? 1 : 0,
+          updatedOrder.id,
+        ])).thenAnswer((_) async => 1);
+    when(() => databaseMock.rawDelete(any(), [updatedOrder.id]))
+        .thenAnswer((_) async => 1);
+
+    final int result = await ordersRepository.updateOrder(updatedOrder);
+    expect(result, 1);
+  });
+}

--- a/test/app/core/data/products/product_repository_test.dart
+++ b/test/app/core/data/products/product_repository_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:quiosque/app/core/data/dtos/product_dto.dart';
+import 'package:quiosque/app/core/data/products/product_repository.dart';
+import 'package:quiosque/app/core/database/db_connection.dart';
+import 'package:sqflite/sqflite.dart';
+
+import '../../../../mocked_data.dart';
+
+class DatabaseMock extends Mock implements Database {}
+
+class DbConnectionMock extends Mock implements DbConnection {}
+
+void main() {
+  final dbConnectionMock = DbConnectionMock();
+  final databaseMock = DatabaseMock();
+  final ProductRepository productRepository =
+      ProductRepository(dbConnectionMock);
+
+  setUp(() {
+    when(() => dbConnectionMock.openConnection())
+        .thenAnswer((_) async => databaseMock);
+  });
+
+  test('Should return a list of products', () async {
+    when(() => databaseMock.rawQuery(any()))
+        .thenAnswer((_) async => mockedProductsList);
+
+    final result = await productRepository.getAllProducts();
+    expect(result.length, 3);
+  });
+
+  test('Should return id when a new product is added', () async {
+    final ProductDTO newProduct =
+        ProductDTO(product: 'Guaraná Antártica', price: 4.99);
+    when(() => databaseMock
+            .rawInsert(any(), [newProduct.product, newProduct.price]))
+        .thenAnswer((_) async => 4);
+
+    final result = await productRepository.createProduct(newProduct);
+    expect(result, 4);
+  });
+
+  test('Should return the number of affected lines when a product is removed',
+      () async {
+    const int productId = 4;
+    when(() => databaseMock.rawDelete(any(), [productId]))
+        .thenAnswer((_) async => productId);
+
+    final result = await productRepository.deleteProduct(productId);
+    expect(result, productId);
+  });
+
+  test('Should return the number of affected lines when a product is updated',
+      () async {
+    final ProductDTO updatedProduct =
+        ProductDTO(product: 'Guaraná Antártica', price: 3.99, id: 4);
+    when(() => databaseMock.rawUpdate(any(), [
+          updatedProduct.product,
+          updatedProduct.price,
+          updatedProduct.id,
+        ])).thenAnswer((_) async => updatedProduct.id!);
+
+    final int result = await productRepository.updateProduct(updatedProduct);
+    expect(result, updatedProduct.id);
+  });
+}

--- a/test/mocked_data.dart
+++ b/test/mocked_data.dart
@@ -1,0 +1,35 @@
+final List<Map<String, dynamic>> mockedProductsList = [
+  {
+    'id': 1,
+    'product': 'Suco de laranja',
+    'price': 6.99,
+  },
+  {
+    'id': 2,
+    'product': 'Coca-cola Lata',
+    'price': 4.99,
+  },
+  {
+    'id': 3,
+    'product': 'Água mineral sem gás',
+    'price': 2.99,
+  },
+];
+
+final List<Map<String, dynamic>> mockedOrdersList = [
+  {
+    'id': 1,
+    'table_number': 1,
+    'status': 0,
+  },
+  {
+    'id': 2,
+    'table_number': 2,
+    'status': 1,
+  },
+  {
+    'id': 3,
+    'table_number': 1,
+    'status': 1,
+  },
+];


### PR DESCRIPTION
This PR implements some tests for database repositories. During the tests writing, it was found a necessary change in orders_repository transaction, that now returns the new order ID in createOrder method and the amount of affected lines in updateOrder method.

Fixes #29 