### PR TITLE
Changed orderId source to proper store

### DIFF
--- a/lib/app/modules/table_order/table_order_page.dart
+++ b/lib/app/modules/table_order/table_order_page.dart
@@ -78,7 +78,8 @@ class _TableOrderPageState extends State<TableOrderPage> {
                 tableNumber: data.tableNumber,
                 onOrderCreated: () {
                   _orderProductsStore.createOrder(
-                      tableNumber: data.tableNumber);
+                    tableNumber: data.tableNumber,
+                  );
                 },
               );
             } else {
@@ -93,7 +94,8 @@ class _TableOrderPageState extends State<TableOrderPage> {
                     quantity: quantity,
                   );
                   await _orderProductsStore.updateOrderProducts(updatedProduct);
-                  await _orderProductsStore.fetchOrderProducts(data.orderId!);
+                  await _orderProductsStore
+                      .fetchOrderProducts(_orderProductsStore.orderId!);
                 },
               );
             }


### PR DESCRIPTION
The issue reported in #58 was caused due to getting orderId information from data sent by the previous screen.

So, when a table with no opened order was selected, initially the orderId was null. And, when an order was created, this value was not replaced.

Hence, when a product was added, it was linked to an inexistent order, and that was causing the error.

The solution was using the `_orderProductsStore.orderId` instead of `data.orderId` in lines 92 and 98 in `table_order_page.dart` file.