### PR TITLE
Created Navigation Drawer widget and added other pages draft

### DIFF
--- a/lib/app/app_widget.dart
+++ b/lib/app/app_widget.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:quiosque/app/modules/categories/categories_page.dart';
 import 'package:quiosque/app/modules/home/home_page.dart';
+import 'package:quiosque/app/modules/products/products_page.dart';
 import 'package:quiosque/app/modules/splash/splash_screen.dart';
 import 'package:quiosque/app/modules/table_order/table_order_page.dart';
 
@@ -37,6 +39,8 @@ class AppWidget extends StatelessWidget {
         SplashScreen.route: (context) => const SplashScreen(),
         HomePage.route: (context) => const HomePage(),
         TableOrderPage.route: (context) => const TableOrderPage(),
+        ProductsPage.route: (context) => const ProductsPage(),
+        CategoriesPage.route: (context) => const CategoriesPage(),
       },
     );
   }

--- a/lib/app/core/widgets/menu_drawer_header_widget.dart
+++ b/lib/app/core/widgets/menu_drawer_header_widget.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+class MenuDrawerHeaderWidget extends StatelessWidget {
+  const MenuDrawerHeaderWidget({
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 130.0,
+      alignment: Alignment.centerLeft,
+      color: Theme.of(context).primaryColor,
+      child: const DrawerHeader(
+        margin: EdgeInsets.zero,
+        child: SizedBox(
+          width: double.maxFinite,
+          child: Text(
+            'Menu',
+            style: TextStyle(
+              fontSize: 24.0,
+              fontWeight: FontWeight.w600,
+              color: Colors.white,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/app/core/widgets/menu_drawer_tile_widget.dart
+++ b/lib/app/core/widgets/menu_drawer_tile_widget.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class MenuDrawerTileWidget extends StatelessWidget {
+  const MenuDrawerTileWidget({
+    Key? key,
+    required this.title,
+    required this.leading,
+    required this.selected,
+    required this.routeName,
+  }) : super(key: key);
+
+  final String title;
+  final Widget leading;
+  final bool selected;
+  final String routeName;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(title),
+      leading: leading,
+      selectedTileColor: Theme.of(context).primaryColor,
+      selectedColor: Colors.white,
+      selected: selected,
+      onTap: () => Navigator.of(context).pushReplacementNamed(routeName),
+    );
+  }
+}

--- a/lib/app/core/widgets/menu_drawer_widget.dart
+++ b/lib/app/core/widgets/menu_drawer_widget.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:quiosque/app/core/widgets/menu_drawer_tile_widget.dart';
+import 'package:quiosque/app/modules/categories/categories_page.dart';
+import 'package:quiosque/app/modules/home/home_page.dart';
+import 'package:quiosque/app/modules/products/products_page.dart';
+
+import 'menu_drawer_header_widget.dart';
+
+class MenuDrawerWidget extends StatelessWidget {
+  const MenuDrawerWidget({Key? key, required this.routeName}) : super(key: key);
+
+  final String routeName;
+
+  @override
+  Widget build(BuildContext context) {
+    return Drawer(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const MenuDrawerHeaderWidget(),
+          Expanded(
+            child: ListView(
+              padding: EdgeInsets.zero,
+              children: [
+                MenuDrawerTileWidget(
+                  title: 'Mesas',
+                  leading: Image.asset(
+                    'images/mesa_o.png',
+                    width: 24.0,
+                    height: 24.0,
+                    color: routeName == HomePage.route
+                        ? Colors.white
+                        : Colors.grey,
+                  ),
+                  selected: routeName == HomePage.route,
+                  routeName: HomePage.route,
+                ),
+                MenuDrawerTileWidget(
+                  title: 'Produtos',
+                  leading: const Icon(Icons.format_list_bulleted_rounded),
+                  selected: routeName == ProductsPage.route,
+                  routeName: ProductsPage.route,
+                ),
+                MenuDrawerTileWidget(
+                  title: 'Categorias',
+                  leading: const Icon(Icons.style_outlined),
+                  selected: routeName == CategoriesPage.route,
+                  routeName: CategoriesPage.route,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/app/modules/categories/categories_page.dart
+++ b/lib/app/modules/categories/categories_page.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:quiosque/app/core/widgets/menu_drawer_widget.dart';
+
+class CategoriesPage extends StatefulWidget {
+  const CategoriesPage({Key? key}) : super(key: key);
+
+  static String route = '/categories';
+
+  @override
+  _CategoriesPageState createState() => _CategoriesPageState();
+}
+
+class _CategoriesPageState extends State<CategoriesPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Categories'),
+      ),
+      drawer: MenuDrawerWidget(routeName: CategoriesPage.route),
+      body: Container(),
+    );
+  }
+}

--- a/lib/app/modules/home/home_page.dart
+++ b/lib/app/modules/home/home_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:get_it/get_it.dart';
 import 'package:quiosque/app/core/data/dtos/table_order_page_dto.dart';
 import 'package:quiosque/app/core/stores/orders_store.dart';
+import 'package:quiosque/app/core/widgets/menu_drawer_widget.dart';
 import 'package:quiosque/app/modules/home/home_controller.dart';
 import 'package:quiosque/app/modules/home/widgets/table_widget.dart';
 import 'package:quiosque/app/modules/table_order/table_order_page.dart';
@@ -44,6 +45,7 @@ class _HomePageState extends State<HomePage> {
           centerTitle: true,
           title: Text(title),
         ),
+        drawer: MenuDrawerWidget(routeName: HomePage.route),
         body: Observer(
           builder: (_) {
             if (ordersStore.loading) {

--- a/lib/app/modules/products/products_page.dart
+++ b/lib/app/modules/products/products_page.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:quiosque/app/core/widgets/menu_drawer_widget.dart';
+
+class ProductsPage extends StatefulWidget {
+  const ProductsPage({Key? key}) : super(key: key);
+
+  static String route = '/products';
+
+  @override
+  _ProductsPageState createState() => _ProductsPageState();
+}
+
+class _ProductsPageState extends State<ProductsPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Products'),
+      ),
+      drawer: MenuDrawerWidget(routeName: ProductsPage.route),
+      body: Container(),
+    );
+  }
+}


### PR DESCRIPTION
It was created a Navigation Drawer named _MenuDrawerWidget_ and it was added to all pages.

Additionally, in order to complete at least its logic, it was created a draft page for _products_ and _categories_, and their route was added to the _AppWidget_ class.

Closes #81 